### PR TITLE
Handle non-array keys as if they were single-element array

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -1,0 +1,5 @@
+declare class ArrayKeyedMap<K, V> extends Map<K, V> {
+    hasPrefix(k: ReadonlyArray<any>): boolean;
+}
+
+export = ArrayKeyedMap;

--- a/main.js
+++ b/main.js
@@ -101,6 +101,7 @@ module.exports = ArrayKeyedMap
 
 function set (path, value) {
   let map = this._root
+  if (!Array.isArray(path)) { path = [path] }
   for (const item of path) {
     let nextMap = map.get(item)
     if (!nextMap) {
@@ -120,6 +121,7 @@ function set (path, value) {
 
 function has (path) {
   let map = this._root
+  if (!Array.isArray(path)) { path = [path] }
   for (const item of path) {
     const nextMap = map.get(item)
     if (nextMap) {
@@ -133,6 +135,7 @@ function has (path) {
 
 function get (path) {
   let map = this._root
+  if (!Array.isArray(path)) { path = [path] }
   for (const item of path) {
     map = map.get(item)
     if (!map) return undefined
@@ -147,6 +150,7 @@ function del (path) {
   // if we delete something.
   const stack = []
 
+  if (!Array.isArray(path)) { path = [path] }
   for (const item of path) {
     const nextMap = map.get(item)
     if (nextMap) {
@@ -177,6 +181,7 @@ function del (path) {
 
 function hasPrefix (path) {
   let map = this._root
+  if (!Array.isArray(path)) { path = [path] }
   for (const item of path) {
     map = map.get(item)
     if (!map) return false

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.2",
   "description": "a map from arrays of values to values",
   "main": "main.js",
+  "types": "main.d.ts",
   "scripts": {
     "test": "npm run test-code && npm run test-docs",
     "test-docs": "txm readme.md",

--- a/test.js
+++ b/test.js
@@ -27,6 +27,15 @@ test('set/get path len 1', (t) => {
   t.end()
 })
 
+test('set/get non-array acts like len 1', (t) => {
+  const p = new AKM()
+  p.set('abc', true)
+  t.same(p.get(['abc']), true)
+  p.set(['def'], true)
+  t.same(p.get('def'), true)
+  t.end()
+})
+
 test('set/get path len 2', (t) => {
   const p = new AKM()
   p.set(['a', 'b'], true)
@@ -181,6 +190,16 @@ test('delete return value', t => {
   t.end()
 })
 
+test('delete supports non-array key', t => {
+  const p = new AKM()
+
+  p.set(['x'], 'x')
+  t.same(p.delete('x'), true, 'delete returns true when entry existed')
+  t.same(p.delete('x'), false, 'delete returns false when no entry existed')
+
+  t.end()
+})
+
 test('has', (t) => {
   const p = new AKM()
 
@@ -188,9 +207,11 @@ test('has', (t) => {
 
   t.same(p.has(['a', 'b']), true)
   t.same(p.has(['a']), false)
+  t.same(p.has('a'), false)
 
   p.set(['a'], 'a')
   t.same(p.has(['a']), true)
+  t.same(p.has('a'), true)
 
   t.end()
 })
@@ -342,14 +363,17 @@ test('hasPrefix', (t) => {
   const p = new AKM()
   p.set(['a', 'b', 'c'], 'abc')
   p.set(['c'], 'c')
+  p.set([123, 456], 'd')
 
   t.ok(p.hasPrefix([]))
+  t.ok(p.hasPrefix(['a']))
   t.ok(p.hasPrefix(['a']))
   t.ok(p.hasPrefix(['a', 'b']))
   t.ok(p.hasPrefix(['a', 'b', 'c']))
   t.ok(!p.hasPrefix(['a', 'b', 'c', 'd']))
   t.ok(!p.hasPrefix(['b']))
   t.ok(p.hasPrefix(['c']))
+  t.ok(p.hasPrefix(123))
 
   t.end()
 })


### PR DESCRIPTION
The current documented behavior expects Arrays for the `path` argument to all relevant methods, but actually uses a for-of loop so any iterable will appear to work.  However, this means that `map.set("key", "value")` is actually treated as `map.set(["k", "e", "y"], "value")`.

This PR treats all non-array path arguments as a single-item array, allowing `get("key")` as shorthand for `get(["key"])`.  I think I have unit tests for everything and `standard` passes.

I also added very rudimentary TypeScript typings, but as a separate commit so it's easy to remove if you would prefer.